### PR TITLE
Fixed Typo: 'Finnished' to 'Finished'.

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
     <string name="action_refresh">Refresh file list</string>
     <string name="details_ready">Ready to convert!</string>
     <string name="details_exists">Output already exists...</string>
-    <string name="details_done">Finnished!</string>
+    <string name="details_done">Finished!</string>
     <string name="action_keep_ecm">Keep .ecm files</string>
     <string name="search_title">Searching for ecm files on your device...</string>
     <string name="search_details_found">file(s) found</string>


### PR DESCRIPTION
This is just a small pull request(also my first one on Github) to fix a typo as well as get used to using Git as a whole. It just changes the `details_done` string to be defined as "Finished" instead of "Finnished". 
